### PR TITLE
fixing Python 3.6 import problem

### DIFF
--- a/gitautodeploy/cli/config.py
+++ b/gitautodeploy/cli/config.py
@@ -352,7 +352,11 @@ def init_config(config):
     import os
     import re
     import logging
-    from ..models import Project
+    try:
+        from ..models import Project
+    except ValueError:
+        from gitautodeploy.models import Project
+        
     logger = logging.getLogger()
 
     # Translate any ~ in the path into /home/<user>

--- a/gitautodeploy/httpserver.py
+++ b/gitautodeploy/httpserver.py
@@ -94,7 +94,10 @@ def WebhookRequestHandlerFactory(config, event_store, server_status, is_https=Fa
             import logging
             import json
             import threading
-            from urlparse import parse_qs
+            try:
+                from urlparse import parse_qs
+            except ModuleNotFoundError:
+                from urllib.parse import parse_qs
 
             logger = logging.getLogger()
 


### PR DESCRIPTION
taken over from https://github.com/olipo186/Git-Auto-Deploy/pull/238

> By running command python -m gitautodeploy --config config.json on python 3.6.8 I have received error:
> 
> git-auto-deploy/gitautodeploy/cli/config.py", line 355, in init_config
    from ..models import Project
ValueError: attempted relative import beyond top-level package
which is easily fixed (with backwards compatibility) with a try/except clause. Point is that python 3 changes relative includes which also means we need to be package dependent.